### PR TITLE
use `process.exit(1)` instead of `throw er`

### DIFF
--- a/bin/fullfat.js
+++ b/bin/fullfat.js
@@ -77,7 +77,7 @@ ff.on('start', function() {
   console.log('DELETE %s', change.id)
 }).on('error', function(er) {
   console.log('ERROR', er)
-  throw er
+  process.exit(1)
 }).on('download', function(a) {
   console.log('-> %s', a.name)
 }).on('upload', function(a) {


### PR DESCRIPTION
Ensures better determinism when we get in a bad state in regards to exit codes. I've seem some unclean exits in some cases.
